### PR TITLE
Fixed numerous issues with custom_derivatives() that were causing errors

### DIFF
--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -1,9 +1,9 @@
 using Lux
 using Random 
 
-function build_custom_derivs_function_R(f_julia,p_julia,inputs,outputs)
-
-  NN = Lux.Chain(Lux.Dense(length(inputs),10,tanh),Lux.Dense(10,outputs))
+function build_custom_derivs_function_R(f_julia,p_julia,inputs,hidden_units,outputs)
+  inputs, hidden_units, outputs = [inputs,hidden_units,outputs] .|> Integer
+  NN = Lux.Chain(Lux.Dense(length(inputs),hidden_units,tanh),Lux.Dense(hidden_units,outputs))
   rng = Random.default_rng()
   params, states = Lux.setup(rng,NN)
   init_params = (rparams = p_julia, NN = params, )

--- a/src/model_constructors.R
+++ b/src/model_constructors.R
@@ -91,14 +91,14 @@ custom_derivatives <- function(
   julia_assign("data_julia",data)
   julia_assign("inputs",neural_network_inputs)
   julia_assign("outputs",neural_network_outputs)
+  julia_assign("hidden_units", hidden_units)
   
-  julia_model <- julia_eval("deriv, parameters = build_custom_derivs_function_R(f_julia,p_julia,inputs,outputs)")
+  julia_model <- julia_eval("deriv, parameters = build_custom_derivs_function_R(f_julia,p_julia,inputs,hidden_units,outputs)")
   
   if(is.null(covariates)){
     julia_model <- julia_eval(paste0(model_type,
                      "(data_julia,deriv,parameters,time_column_name=\"",time_column_name,
-                     "\",hidden_units=",hidden_units,
-                     ",seed=",seed,
+                     "\"",
                      ",proc_weight=",proc_weight,
                      ",obs_weight=",obs_weight,
                      ",reg_weight=",reg_weight,
@@ -110,8 +110,7 @@ custom_derivatives <- function(
     julia_assign("covariates_julia",covariates)
     julia_model <- julia_eval(paste0(model_type,
                      "(data_julia,covariates_julia,deriv,parameters,time_column_name=\"",time_column_name,
-                     "\",hidden_units=",hidden_units,
-                     ",seed=",seed,
+                     "\"",
                      ",proc_weight=",proc_weight,
                      ",obs_weight=",obs_weight,
                      ",reg_weight=",reg_weight,

--- a/tst/wrappers-vs-env.Rmd
+++ b/tst/wrappers-vs-env.Rmd
@@ -1,0 +1,20 @@
+```{r setup}
+library(tidyverse)
+library(JuliaCall)
+source("../src/emude.R")
+#source(file = "../src/model_constructors.R")
+```
+
+```{r}
+ude <- emude_setup()
+```
+
+
+```{r}
+data = tibble("t" = c(1,2,3,4,5), "value" = c(2,4,8,16,32))
+
+custom_derivatives(data=data, derivs = "./derivs_from_r.jl", initial_parameters = list(r=0.5, b=0.5), neural_network_inputs = 1,
+                    neural_network_outputs = 1, hidden_units = 10, time_column_name = "t"
+                   )
+```
+


### PR DESCRIPTION
Fixed keyword args of custom_derivatives() to match the keyword args present in UniversalDiffEq

Fixed build_custom_derivatives_function_R() so that the hidden_units keyword arg dictates the number of hidden nodes. Also changed the function to cast the arguments specifying neural network size to int as they were being set as float64 and causing errors

added testing file for testing wrapper vs. environment interactions